### PR TITLE
New links for partners

### DIFF
--- a/_includes/software.html
+++ b/_includes/software.html
@@ -34,7 +34,7 @@
                         <h5>PRISMS-PF</h5>
                       </div>
                       <div class="panel-body">
-                        <a href="https://github.com/prisms-center/phaseField">PRISMS-PF</a> is a powerful, massively parallel finite element code for conducting phase field and other related simulations of microstructural evolution.
+                        <a href="http://prisms-center.github.io/phaseField/">PRISMS-PF</a> is a powerful, massively parallel finite element code for conducting phase field and other related simulations of microstructural evolution.
                       </div>
                    </div>
               </div>
@@ -46,7 +46,7 @@
                         <h5>MDF</h5>
                       </div>
                       <div class="panel-body">
-                        The <a href="https://github.com/materials-data-facility">MDF</a> is a set of data services built specifically to support materials science researchers.
+                        The <a href="https://materialsdatafacility.org/">MDF</a> is a set of data services built specifically to support materials science researchers.
                       </div>
                   </div>
               </div>
@@ -66,7 +66,7 @@
                         <h5>MDF Connect</h5>
                       </div>
                       <div class="panel-body">
-                        The <a href="https://github.com/materials-data-facility/connect">MDF Connect</a> service is the ETL flow to deeply index datasets into MDF Search.
+                        The <a href="https://connect.materialsdatafacility.org/">MDF Connect</a> service is the ETL flow to deeply index datasets into MDF Search.
                       </div>
                    </div>
               </div>


### PR DESCRIPTION
Direct visitors to homepage of projects where possible, instead of Github repos.