### PR TITLE
Fixes for MAST

### DIFF
--- a/_includes/software.html
+++ b/_includes/software.html
@@ -14,7 +14,7 @@
                         <h5>MAST</h5>
                       </div>
                       <div class="panel-body">
-                        <a href="https://mast-group.github.io/">MAST</a> provides tools and workflows that make machine learning easier for materials scientists.
+                        <a href="https://github.com/uw-cmg/MAST">MAST</a> is an automated workflow manager and post-processing tool that focuses on performing diffusion and defect calculations using Density Functional Theory.
                       </div>
                   </div>
               </div>


### PR DESCRIPTION
MAST does not do ML, switched to using description from UW page.

Also changed link to point to MAST GitHub page.